### PR TITLE
user save return Promise.reject when passwords do not match

### DIFF
--- a/.core/lib/user.js
+++ b/.core/lib/user.js
@@ -375,7 +375,7 @@ User.save = async (params, options) => {
         if (params.password === null) {
             op.del(params, 'password');
         } else if (!params.confirm || params.password !== params.confirm) {
-            return new Error('passwords do not match');
+            return Promise.reject(new Error('passwords do not match'));
         }
     }
 


### PR DESCRIPTION
Fix done from Actinium to make it to Actinium-Plugins. Allows clients to receive 400 validation message when passwords don't match.