### PR TITLE
Update parse-dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "npm-run-all": "^4.1.5",
         "object-path": "^0.11.8",
         "parse": "^3.4.3",
-        "parse-dashboard": "^2.1.0",
+        "parse-dashboard": "^4.1.4",
         "parse-server": "^4.10.4",
         "pluralize": "^8.0.0",
         "promise": "^8.1.0",


### PR DESCRIPTION
Update parse-dashboard, as it does not install on linux earlier than 2.2.0