### PR TITLE
User Scaleability Issues

### DIFF
--- a/.core/lib/roles.js
+++ b/.core/lib/roles.js
@@ -170,6 +170,24 @@ Roles.load = (options = { useMasterKey }) =>
         },
     });
 
+Roles.User.getMany = (users = []) => {
+    const byUser = users.reduce((init, user) => {
+        init[user.id || user.objectId] = { anonymous: 0 };
+        return init;
+    }, {});
+
+    const allRoles = Object.values(Roles.get());
+    allRoles.forEach(role => {
+        const { users = {}, name, level } = role;
+        Object.values(users).forEach(user => {
+            const id = user.id || user.objectId;
+            if (id in byUser) byUser[id][name] = level;
+        });
+    });
+
+    return byUser;
+};
+
 Roles.User.get = search => {
     return _.chain(
         Object.values(Roles.get()).filter(({ users = {} }) => {


### PR DESCRIPTION
To aid in user scaleability add SDK functions Actinium.Roles.User.getMany() and Actinium.Capability.User.getMany(), so that afterFind operations can map roles and capabilities efficiently.

The current implementation of the users-plugin afterFind suffers from a significatnt loading delay as user collection grows. This will need to be addressed to fully fix this issue.